### PR TITLE
Feat/usedatahooks 온보딩페이지에 로그인모달 컴포넌트 이식 및 수정 , 데이터와 유저상태 조회 훅 완성하였습니다.

### DIFF
--- a/src/components/Button/EnterButton.tsx
+++ b/src/components/Button/EnterButton.tsx
@@ -1,8 +1,12 @@
 import styled from 'styled-components';
 
-function EnterButton() {
+interface enterButtonProps {
+  onClick?: () => void;
+}
+
+function EnterButton({onClick}: enterButtonProps) {
   return (
-    <ButtonDiv type="button">
+    <ButtonDiv type="button" onClick={onClick}>
       <ButtonText>탐험하기</ButtonText>
     </ButtonDiv>
   );
@@ -14,11 +18,15 @@ const ButtonDiv = styled.button`
   width: 105px;
   height: 43px;
   border-radius: 15px;
+  border: 1px solid var(--bs-black-300);
   background-color: #f7f7f7;
   cursor: pointer;
+  &:hover {
+    box-shadow: rgba(255, 255, 255, 0.317) 0px 2px 4px 0px, rgba(255, 255, 255, 0.595) 0px 2px 16px 0px;
+  }
 `;
 
 const ButtonText = styled.span`
-  font-size: 24px;
-  color: #555555;
+  font-size: 16px;
+  color: var(--bs-black-300);
 `;

--- a/src/components/LandingPage/LandingHeader.tsx
+++ b/src/components/LandingPage/LandingHeader.tsx
@@ -1,15 +1,28 @@
 import styled from 'styled-components';
 import EnterButton from '../Button/EnterButton';
 import Logo from '@/assets/landing/landing-logo.svg';
+import { useRef, useState } from 'react';
+import LoginModal from '../LoginModal';
+
 
 function LandingHeader() {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const [allSizeModalShow, setAllSizeModalShow] =useState(false);
+
+  const modalOutSideClick = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    if(modalRef.current === e.target) {
+      setAllSizeModalShow(false)
+  }  }
+
   return (
     <MainBox>
       <ImgBox>
         <img src={Logo} alt="JUNGLE 로고 이미지" />
       </ImgBox>
       <BtnBox>
-        <EnterButton />
+        <EnterButton onClick={()=>{setAllSizeModalShow(true)}}/>
+        {allSizeModalShow &&  
+          <LoginModal modalRef={modalRef} modalOutSideClick={modalOutSideClick}/>}
       </BtnBox>
     </MainBox>
   );
@@ -30,6 +43,5 @@ const ImgBox = styled.div`
 `;
 
 const BtnBox = styled.div`
-  display: flex;
-  gap: 20px;
+  
 `;

--- a/src/components/LoginModal.tsx
+++ b/src/components/LoginModal.tsx
@@ -42,10 +42,11 @@ const OutBox = styled.div `
 width: 100%;
 height: 100%;
 background-color: rgba(0, 0, 0, 0.52);
-
+z-index: 9999;
 top: 0;
 left: 0;
 position: fixed;
+color: var(--bs-black-100);
 
 `;
 

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -1,6 +1,8 @@
 import { supabase } from '@/client';
-import { create } from 'zustand';
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 
+import { create } from 'zustand';
 
 
 type State = {
@@ -18,15 +20,19 @@ const initialAuthState = {
   token: '',
 };
 
+
 export const useAuthStore = create<State>((set) => {
+  
+
   const handleLogin: State['handleLogin'] = async () => {
     const { data, error } = await supabase.auth.signInWithOAuth({ provider: 'github' });
-
+    
     if (error) {
       console.error("Error during sign in: ", error);
     } else {
       console.log("Signed in successfully: ", data);
       set({ isAuth: true });
+
 
     }
   };
@@ -36,11 +42,9 @@ export const useAuthStore = create<State>((set) => {
     
     if (error) {
       console.error("Error during sign out: ", error);
-      
     } else {
       console.log("Signed out successfully");
       set({ isAuth: false });
-    
     }
   };
 
@@ -76,3 +80,16 @@ export const useAuthStore = create<State>((set) => {
     deleteUser 
   };
 });
+
+export function MyComponent() {
+  const navigate = useNavigate();
+  const { isAuth } = useAuthStore();
+
+  useEffect(() => {
+    if (isAuth) {
+      navigate('/main');
+    }
+  }, [isAuth, navigate]);
+
+  // ...
+}

--- a/src/store/useDataStore.ts
+++ b/src/store/useDataStore.ts
@@ -1,23 +1,33 @@
 import create from 'zustand';
 import { supabase } from '@/client';
+import { User } from '@supabase/supabase-js';
+
 
 type DataType = {
-  id: number;
+  id: number | string;
   [key: string]: number | string;
+  title: string;
+  created_at: string;
+  text: string;
+  
 };
 
 type State = {
   data: DataType[];
+  user: User | null;
   setData: (data: DataType[]) => void;
   getListData: (tableName: string) => Promise<void>;
   getIdData: (tableName: string, id: number) => Promise<void>;
   createData: (tableName: string, newData: DataType) => Promise<void>;
   updateData: (tableName: string, id: number, updatedData: DataType) => Promise<void>;
   deleteData: (tableName: string, id: number) => Promise<void>;
+  getUserData: () => Promise<void>;
 };
 
 const useDataStore = create<State>((set) => ({
+  
   data: [],
+  user: null,
   setData: (data: DataType[]) => set({ data }),
   getListData: async (tableName: string) => {
     const { data, error } = await supabase
@@ -44,7 +54,30 @@ const useDataStore = create<State>((set) => ({
         set({ data });
       }
     }
+
   },
+
+  getUserData: async () => {
+    const { data: { user } } = await supabase.auth.getUser();// 현재 로그인한 사용자의 정보를 가져옵니다.
+  
+    if (user) {
+      set({ user });  // 유저 정보를 상태에 저장합니다.
+    } else {
+      set({ user: null });  // 로그인하지 않은 경우에는 null을 상태에 저장합니다.
+    }
+  },
+  
+  // getUserData: async () => {
+  //   const { data: { user } } = await supabase.auth.getUser()
+  //   if (user !== null) {
+  //     set({ user });
+  //   }else {
+  //     set({ user });
+  //   }
+    
+  // },
+
+  
   createData: async (tableName: string, newData: DataType) => {
     const { data, error } = await supabase
       .from(tableName)


### PR DESCRIPTION
## 📌 관련 이슈(선택)

<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

## ✨ 작업 내용

loginModal 온보딩페이지 이식 후 모달이 최상위에 위치하지 않는 이슈 발견 후
z-index와 absolute로 해결하였습니다.

useDataStore/ useAuthStore 훅 생성하여 데이터 CRUD와 로그인 문제 해결하였습니다.

온보딩페이지에 로그인모달 컴포넌트 이식 및 수정 , 데이터와 유저상태 조회 훅 완성하였습니다.

## ✅ 달성도
87% - 어떤 정보를 가져오냐에 따라 적용된 typescript 및 코드 일부 수정 가능합니다.

## 📸 레퍼런스

<img width="699" alt="image" src="https://github.com/twelive/JUNGLE/assets/73214037/5bc0ea1c-e6f3-4c95-90cb-bfa70abb7a95">

# pnpm i @supabase/supabase-js@latest  설치해주셔야 합니다 
# .env파일에 
`VITE_SUPABASE_URL=https://szpwpecuivecepegybvv.supabase.co

VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN6cHdwZWN1aXZlY2VwZWd5YnZ2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3MDA3MTUyODcsImV4cCI6MjAxNjI5MTI4N30.2aHvPrpCmD2tUdJZArU5CWvkOkKdyZlnJWhyhPGoLjs`

추가하세요

