### PR TITLE
Fix/Header: 메인페이지 -> 클릭이벤트로 카테고리 접근시 헤더 에러

### DIFF
--- a/src/components/Header/HeaderMenu.tsx
+++ b/src/components/Header/HeaderMenu.tsx
@@ -1,6 +1,7 @@
 import { useLocation } from 'react-router-dom';
 import HeaderMenuItem from '@components/Header/HeaderMenuItem';
 import useHeaderMenuStore from '@store/useHeaderMenuStore';
+import getPathName from '@utils/getPathName';
 import styled from 'styled-components';
 
 const DefaultMenu = [
@@ -26,7 +27,7 @@ function HeaderMenu() {
   return (
     <MenuSection>
       <FlexBox>
-        {(pathname.slice(0, 13) !== '/introduction'
+        {(getPathName(pathname) !== '/introduction'
           ? DefaultMenu
           : IntroductionMenu
         ).map((item, index) => (
@@ -39,7 +40,7 @@ function HeaderMenu() {
           </HeaderMenuItem>
         ))}
       </FlexBox>
-      {pathname.slice(0, 13) !== '/introduction' && (
+      {getPathName(pathname) !== '/introduction' && (
         <HeaderMenuItem path="/introduction">소개</HeaderMenuItem>
       )}
     </MenuSection>

--- a/src/components/MainPage/Category.tsx
+++ b/src/components/MainPage/Category.tsx
@@ -1,6 +1,7 @@
-import styled from 'styled-components';
-import ArrowScrollDown from '@components/ArrowScrollDown';
 import { Link } from 'react-router-dom';
+import ArrowScrollDown from '@components/ArrowScrollDown';
+import useHeaderMenuStore from '@store/useHeaderMenuStore';
+import styled from 'styled-components';
 
 interface CategoryProps {
   title?: string;
@@ -15,13 +16,24 @@ function Category({
   href,
   height = '21.875rem',
 }: CategoryProps) {
+  const { setCurrentMenu } = useHeaderMenuStore();
+
+  const handleCategoryLink = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    const categoryLink = (e.target as HTMLElement).closest('a');
+
+    if (categoryLink) {
+      const pathname = categoryLink.href.slice(21);
+      setCurrentMenu(pathname);
+    }
+  };
+
   return (
     <CategorySection $height={height}>
       <CategoryTextBox>
         <Title>{title}</Title>
         <Context>{context}</Context>
       </CategoryTextBox>
-      <LinkBox to={href}>
+      <LinkBox to={href} onClick={handleCategoryLink}>
         <ArrowScrollDown color="var(--bs-black-400)" />
       </LinkBox>
     </CategorySection>

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -2,9 +2,9 @@ import Logo from '@components/Logo';
 import HeaderButtonGroup from '@components/Header/HeaderButtonGroup';
 import HeaderTitle from '@components/Header/HeaderTitle';
 import HeaderMenu from '@components/Header/HeaderMenu';
+import BackButton from '@components/Button/BackButton';
 import useHeaderMenuStore from '@store/useHeaderMenuStore';
 import styled from 'styled-components';
-import BackButton from '@components/Button/BackButton';
 
 function Header({ isMenu = true, isBorder = true, isBack = true }) {
   const { currentMenu } = useHeaderMenuStore();

--- a/src/utils/getPathName.ts
+++ b/src/utils/getPathName.ts
@@ -1,0 +1,5 @@
+function getPathName(pathname: string) {
+  return pathname.slice(0, 13);
+}
+
+export default getPathName;


### PR DESCRIPTION
## 📌 관련 이슈
closed to #23

## ✨ 작업 내용
- 헤더 내에서 버튼을 클릭할경우 `closest` 메서드를 통해 부모요소 중에서 가장 가까운 HTMLAnchorElement를 반환합니다.
- 이후 현재 경로에 맞게 useHeaderMenuStore를 사용하여 pathname을 변경합니다.
- 이동된 현재 링크에 맞게 타이틀과 클릭 메뉴가 작동합니다.

## ✅ 달성도
- 뒤로가기 버튼 또한 같은 헤더 오류가 발생함을 확인하여 수정할 예정입니다.

## 📸 레퍼런스

<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요. <br> 참고할 사항 또는 궁금한 사항이 있다면 적어주세요 -->
