### PR TITLE
Feat/MyPage/Main: 인증 유저 정보를 통한 사용자 이름, 알맞은 경로 출력

### DIFF
--- a/src/components/Header/HeaderMenuItem.tsx
+++ b/src/components/Header/HeaderMenuItem.tsx
@@ -1,6 +1,10 @@
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import HeaderMenuItemEvent from '@components/Header/HeaderMenuItemEvent';
 import useHeaderMenuStore from '@store/useHeaderMenuStore';
+import useDataStore from '@store/useDataStore';
+import getPathName from '@utils/getPathName';
+import getUserName from '@utils/getUserName';
 import styled from 'styled-components';
 
 interface HeaderMenuItemProps {
@@ -15,16 +19,29 @@ function HeaderMenuItem({
   isEvent = false,
 }: HeaderMenuItemProps) {
   const { setCurrentMenu } = useHeaderMenuStore();
+  const {user, getUserData} = useDataStore();
+  const [userPath, setUserPath] = useState<string>('/mypage');
 
   const handleToggleTitle = (url: string) => {
     setCurrentMenu(url);
   };
 
+  useEffect(() => {
+    const fetchData = async () => {
+      await getUserData();
+      if (user) {
+        setUserPath(`/mypage/${getUserName(user.email)}`);
+      }
+    };
+
+    fetchData();
+  }, [getUserData, user]);
+
   return (
     <FlexBox>
       {isEvent && <HeaderMenuItemEvent />}
       <StyledLink
-        to={path}
+        to={getPathName(path, 7) === '/mypage' ? userPath : path}
         $event={isEvent}
         onClick={() => handleToggleTitle(path)}
       >

--- a/src/components/MainPage/Category.tsx
+++ b/src/components/MainPage/Category.tsx
@@ -23,7 +23,7 @@ function Category({
 
     if (categoryLink) {
       const pathname = categoryLink.href.slice(21);
-      setCurrentMenu(pathname);
+      setCurrentMenu(pathname);     
     }
   };
 

--- a/src/components/MainPage/CategorySection.tsx
+++ b/src/components/MainPage/CategorySection.tsx
@@ -1,12 +1,29 @@
+import { useEffect } from 'react';
 import Category from '@components/MainPage/Category';
+import useDataStore from '@store/useDataStore';
+import getUserName from '@utils/getUserName';
 import styled from 'styled-components';
 
 function CategorySection() {
+  const {user, getUserData} = useDataStore();
+  
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        await getUserData();
+      } catch (error) {
+        console.error('Error fetching data:', error);
+      }
+    };
+    
+    fetchData();
+  }, [getUserData]);
+
   return (
     <CategoryBox>
       <TopLayout>
         <RightLayout>
-          <Category href="/mypage" title="내 활동" />
+          <Category href={`/mypage/${getUserName(user?.email)}`} title="내 활동" />
         </RightLayout>
         <Category href="/job" title="취업" />
       </TopLayout>

--- a/src/components/MyPage/ProfileSection.tsx
+++ b/src/components/MyPage/ProfileSection.tsx
@@ -1,13 +1,22 @@
+import { useEffect } from 'react';
 import styled from 'styled-components';
 import Profile from '@components/MyPage/Profile';
+import useDataStore from '@store/useDataStore';
+import getUserName from '@utils/getUserName';
 
-function ProfileSection({ user = 'userName' }) {
+function ProfileSection() {
+  const {user, getUserData} = useDataStore();
+
+  useEffect(()=> {
+    getUserData();
+  },[getUserData]);
+
   return (
     <ProfileBox>
       <h2 className="sr-only">프로필</h2>
       <Profile />
       <ProfileText>
-        어서오세요 {user}님, <br /> 지금까지의 활동내역을 보여드립니다.
+        어서오세요 {getUserName(user?.email)}님, <br /> 지금까지의 활동내역을 보여드립니다.
       </ProfileText>
     </ProfileBox>
   );

--- a/src/components/MyPage/ResumeLink.tsx
+++ b/src/components/MyPage/ResumeLink.tsx
@@ -1,11 +1,16 @@
+// import { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import ArrowClickLink from '@assets/common/arrow-clickLink.svg';
+import useDataStore from '@store/useDataStore';
+import getUserName from '@utils/getUserName';
 import styled from 'styled-components';
 
 function ResumeLink() {
+  const {user} = useDataStore();
+
   return (
     <FlexBox>
-      <Link to="/mypage/resume">
+      <Link to={`/mypage/${getUserName(user?.email)}/resume`}>
         <img src={ArrowClickLink} />
       </Link>
       <Heading>이력서</Heading>

--- a/src/layout/RootLayout.tsx
+++ b/src/layout/RootLayout.tsx
@@ -6,8 +6,6 @@ import getPathName from '@utils/getPathName';
 
 export default function RootLayout() {
   const { pathname } = useLocation();
-  console.log(pathname);
-  
 
   return (
     <>

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -26,15 +26,15 @@ const router = createBrowserRouter(
     <Route path="/" element={<RootLayout />}>
       <Route index element={<LandingPage />} />
       <Route path="main" element={<MainPage />} />
-      <Route path="/job" element={<JobSeekPage />} />
-      <Route path="/job/interview" element={<JobInterviewPage />} />
+      <Route path="job" element={<JobSeekPage />} />
+      <Route path="job/interview" element={<JobInterviewPage />} />
       <Route path="study" element={<StudyPage />} />
-      <Route path="mypage" element={<MyPage />} />
-      <Route path="mypage/resume" element={<MyResumePage/>} />
+      <Route path="mypage/:userId" element={<MyPage />} />
+      <Route path="mypage/:userId/resume" element={<MyResumePage/>} />
       <Route path="community" element={<CommunityPage />} />
       <Route path="community/communitycreate" element={<CommunityCreatePage />} />
-      <Route path="/introduction" element={<IntroductionProjectPage />} />
-      <Route path="/introduction/team" element={<IntroductionTeamPage />} />
+      <Route path="introduction" element={<IntroductionProjectPage />} />
+      <Route path="introduction/team" element={<IntroductionTeamPage />} />
     </Route>
   )
 );

--- a/src/utils/getUserName.ts
+++ b/src/utils/getUserName.ts
@@ -1,0 +1,9 @@
+function getUserName(email: string | undefined) {
+  if(email)
+ {
+  const index = [...email].findIndex(element => element === '@');
+  return email.slice(0, index);
+ }
+}
+
+export default getUserName;


### PR DESCRIPTION
## 📌 관련 이슈
  closed #47 

## ✨ 작업 내용
- [x] 인증 토큰 활용한 정보 가져오기
- [x] 유저 정보 렌더링 -> 사용자 이름 출력
- [x] 라우터 기능 구현: 알맞은 경로 출력

## ✅ 달성도
- 60%
- 메인 카테고리에서 내활동 페이지 접근시 한 번 새로고침
또는 헤더 내 기본 경로가 '/main'로 설정되어 정보 없음으로 넘어간 후 렌더링이 실행되어 수정할 계획입니다. Related to #56 

## 📸 레퍼런스
1. 유저 정보 렌더링
![JUNGLE_ProfileText](https://github.com/twelive/JUNGLE/assets/134567469/c60bf74f-1c2d-4c86-be17-d1226305a8ab)

2. 라우터 기능 구현
![JUNGLE_PathName](https://github.com/twelive/JUNGLE/assets/134567469/36b32fd3-627f-4375-8566-4958d1dd9b36)
