### PR TITLE
Fix: 메인페이지 카테고리 -> 내활동 페이지 접근 에러 해결

### DIFF
--- a/src/components/Header/HeaderMenu.tsx
+++ b/src/components/Header/HeaderMenu.tsx
@@ -1,6 +1,8 @@
 import { useLocation } from 'react-router-dom';
 import HeaderMenuItem from '@components/Header/HeaderMenuItem';
 import useHeaderMenuStore from '@store/useHeaderMenuStore';
+import useDataStore from '@store/useDataStore';
+import getUserName from '@utils/getUserName';
 import getPathName from '@utils/getPathName';
 import styled from 'styled-components';
 
@@ -19,9 +21,10 @@ const IntroductionMenu = [
 function HeaderMenu() {
   const { pathname } = useLocation();
   const { currentMenu } = useHeaderMenuStore();
+  const {user} = useDataStore();
 
   const handleToggleMenu = (pageTitle: string) => {
-    return pageTitle === currentMenu.slice(0, -1);
+    return currentMenu && pageTitle === currentMenu.slice(0, -1);
   };
 
   return (
@@ -33,8 +36,8 @@ function HeaderMenu() {
         ).map((item, index) => (
           <HeaderMenuItem
             key={index}
-            path={item.path}
-            isEvent={handleToggleMenu(item.children)}
+            path={item.path !== '/mypage' ? item.path : `/mypage/${getUserName(user?.email)}`}
+            isEvent={handleToggleMenu(item.children) || false}
           >
             {item.children}
           </HeaderMenuItem>

--- a/src/components/Header/HeaderMenuItem.tsx
+++ b/src/components/Header/HeaderMenuItem.tsx
@@ -1,10 +1,6 @@
-import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import HeaderMenuItemEvent from '@components/Header/HeaderMenuItemEvent';
 import useHeaderMenuStore from '@store/useHeaderMenuStore';
-import useDataStore from '@store/useDataStore';
-import getPathName from '@utils/getPathName';
-import getUserName from '@utils/getUserName';
 import styled from 'styled-components';
 
 interface HeaderMenuItemProps {
@@ -19,29 +15,17 @@ function HeaderMenuItem({
   isEvent = false,
 }: HeaderMenuItemProps) {
   const { setCurrentMenu } = useHeaderMenuStore();
-  const {user, getUserData} = useDataStore();
-  const [userPath, setUserPath] = useState<string>('/mypage');
 
   const handleToggleTitle = (url: string) => {
     setCurrentMenu(url);
   };
 
-  useEffect(() => {
-    const fetchData = async () => {
-      await getUserData();
-      if (user) {
-        setUserPath(`/mypage/${getUserName(user.email)}`);
-      }
-    };
-
-    fetchData();
-  }, [getUserData, user]);
 
   return (
     <FlexBox>
       {isEvent && <HeaderMenuItemEvent />}
       <StyledLink
-        to={getPathName(path, 7) === '/mypage' ? userPath : path}
+        to={path}
         $event={isEvent}
         onClick={() => handleToggleTitle(path)}
       >

--- a/src/components/MyPage/ProfileSection.tsx
+++ b/src/components/MyPage/ProfileSection.tsx
@@ -1,15 +1,11 @@
-import { useEffect } from 'react';
+// import { useEffect } from 'react';
 import styled from 'styled-components';
 import Profile from '@components/MyPage/Profile';
 import useDataStore from '@store/useDataStore';
 import getUserName from '@utils/getUserName';
 
 function ProfileSection() {
-  const {user, getUserData} = useDataStore();
-
-  useEffect(()=> {
-    getUserData();
-  },[getUserData]);
+  const {user} = useDataStore();
 
   return (
     <ProfileBox>


### PR DESCRIPTION
## 📌 관련 이슈
Related to #56 

## ✨ 작업 내용
- MainPage 중 CategorySecion 내에서 유저 정보 출력, 접근 경로 에러 모두 해결

## ✅ 달성도
- 60%
- 헤더 내 기본 경로가 '/main' 로 설정되어 에러가 발생되는 CategoryItem isEvent prop, HeaderTitle 수정할 예정입니다.

## 📸 레퍼런스

<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요. <br> 참고할 사항 또는 궁금한 사항이 있다면 적어주세요 -->
