### PR TITLE
Feat: useAuthStore에 본인의 user email 가져오는 로직을 추가하였습니다.

### DIFF
--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -1,7 +1,6 @@
 import { supabase } from '@/client';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-
 import { create } from 'zustand';
 
 
@@ -9,6 +8,8 @@ type State = {
   isAuth: boolean;
   user: string;
   token: string;
+  userEmail: string;
+  userName: string;
   handleLogin: () => Promise<void>;
   handleLogout: () => Promise<void>;
   deleteUser: (id: string) => Promise<void>;
@@ -18,6 +19,8 @@ const initialAuthState = {
   isAuth: false,
   user: '',
   token: '',
+  userEmail: '',
+  userName: '',
 };
 
 
@@ -67,7 +70,7 @@ export const useAuthStore = create<State>((set) => {
     console.log(`Supabase auth event: ${event}`);
 
     if (event === 'SIGNED_IN' && session) {
-      set({ isAuth: true, token: session.access_token, user: session.user.id });
+      set({ isAuth: true, token: session.access_token, user: session.user.id, userEmail: session.user.email });
     } else if (event === 'SIGNED_OUT') {
       set({ ...initialAuthState });
     }


### PR DESCRIPTION
## 📌 관련 이슈(선택)

<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

## ✨ 작업 내용

로그인한 해당유저의 state를 체크하여 가지고 있는 user.email에 접근할 수 있습니다.

## ✅ 달성도

<!-- 예시 <br> - 아이디 입력 시 이메일 형식이 아닐 때 입력창 하단에 안내 문구 표시 <br> - 비밀번호 입력 시 8자 미만일 때 입력창 하단에 안내 문구 표시 -->

## 📸 레퍼런스

<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요. <br> 참고할 사항 또는 궁금한 사항이 있다면 적어주세요 -->
